### PR TITLE
Docs: mark repository as archival and retired

### DIFF
--- a/ARCHIVE_NOTICE.md
+++ b/ARCHIVE_NOTICE.md
@@ -1,0 +1,15 @@
+# Archive notice
+
+This repository is retained as a historical docs surface.
+
+It is **not** the current canonical documentation home.
+
+## Current status
+
+- this repository should be treated as archival
+- active documentation is no longer being advanced here
+- the visible current docs lane in the active stack is the integrated VitePress documentation surface
+
+## Why this notice exists
+
+This repository still appears in searches and old references. The notice is here to reduce confusion and to make the archival state explicit before repository archival is completed through GitHub settings.

--- a/CURRENT_DOCS_HOME.md
+++ b/CURRENT_DOCS_HOME.md
@@ -1,0 +1,22 @@
+# Current documentation home
+
+The active documentation authoring surface is **not** this repository.
+
+## Current verified docs home
+
+The current verified documentation surface is:
+
+- repository: `SocioProphet/socioprophet`
+- docs source: `docs/.vitepress/`
+- public docs mount: `/documentation/`
+
+## What this means
+
+- `socioprophet-docs` is a retired / archival docs repository
+- do **not** add new documentation here
+- do **not** treat this repository as the canonical docs source
+- route documentation changes to the active VitePress docs surface instead
+
+## Why this file exists
+
+This file exists to stop old searches and stale links from sending contributors to the wrong repository.

--- a/RETIRED_REPOSITORY.md
+++ b/RETIRED_REPOSITORY.md
@@ -1,0 +1,9 @@
+# Retired repository
+
+This repository is a retired documentation surface.
+
+It may remain publicly visible for historical reference, but it should not be treated as the authoritative location for current platform documentation.
+
+## Follow-on action
+
+After review of remaining inbound dependencies and links, archive this repository through the GitHub repository settings.


### PR DESCRIPTION
## Summary
- add an explicit archive notice
- add a retired-repository note to reduce confusion while archival is pending

## Why
This repository is no longer the active canonical docs home. The goal here is to make that state explicit before the repository is archived through GitHub settings.

## Scope
Additive notice files only. This PR does not yet archive the repository in GitHub settings.
